### PR TITLE
feat: add hugginggpt footage module

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In this example input for the Script Writer project, we'll explore the world of 
 You'll also need an `input/settings.yml` file to specify the video settings. The settings file should be in the following format:
 
 ```yaml
-footage_engine: "shutterstock" # one of ["shutterstock", "pexels"], default "pexels"
+footage_engine: "shutterstock" # one of ["shutterstock", "pexels", "hugginggpt"], default "pexels"
 footage_engine_settings: # optional per engine settings, check the code in scripts/footage_engines/... for specifics & defaults
   aspect_ratio: "16_9"
 script_style: "funny" # "informative" or "creative" or anything you'd like, default "informative"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
 openai==0.27.4
 jinja2==3.1.2
+# Using the source version of diffusers as it has the * function but latest does not:
+# https://huggingface.co/docs/diffusers/installation#install-from-source
+# https://huggingface.co/docs/diffusers/main/en/api/pipelines/text_to_video
+git+https://github.com/huggingface/diffusers.git

--- a/scripts/footage.py
+++ b/scripts/footage.py
@@ -1,5 +1,6 @@
 from footage_engines.pexels import search as pexels_search
 from footage_engines.shutterstock import search as shutterstock_search
+from footage_engines.hugginggpt import generate as hugginggpt_generate
 
 def add_footage(keyword_script, footage_options):
     engine = footage_options["engine"]
@@ -12,6 +13,8 @@ def add_footage(keyword_script, footage_options):
             clip = pexels_search(prompts, footage_options, used_footage)
         elif engine == "shutterstock":
             clip = shutterstock_search(prompts, footage_options, used_footage)
+        elif engine == "hugginggpt":
+            clip = hugginggpt_generate(prompts, footage_options)
         else:
             raise Exception("Invalid footage engine: " + engine)
 

--- a/scripts/footage_engines/hugginggpt.py
+++ b/scripts/footage_engines/hugginggpt.py
@@ -1,0 +1,19 @@
+import torch
+from diffusers import DiffusionPipeline
+from diffusers.utils import export_to_video
+
+pipe = DiffusionPipeline.from_pretrained("damo-vilab/text-to-video-ms-1.7b", torch_dtype=torch.float16, variant="fp16")
+pipe = pipe.to("cuda")
+
+def upload(video_path):
+	# TODO: implement
+	video_url = "123"
+	return video_url
+
+def generate(prompt, footage_options):
+	# TODO: use footage_options to configure the video, i.e. num_frames
+	video_frames = pipe(prompt, num_frames=128).frames
+	video_path = export_to_video(video_frames)
+	print("video_path:", video_path)
+	video_url = upload(video_path)
+	return video_url


### PR DESCRIPTION
Adds a module to use hugginggpt's text-to-video synthesis:
https://huggingface.co/docs/diffusers/main/en/api/pipelines/text_to_video#texttovideo-synthesis

Browser based demo of the engine:
https://huggingface.co/spaces/damo-vilab/modelscope-text-to-video-synthesis

## Example Output
_coming soon_

**this ran into a roadblock for me as it seems my mac can't support the CUDA operations required https://pytorch.org/get-started/locally/**