### PR TITLE
Create new config pattern

### DIFF
--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,45 +1,76 @@
+import yaml
 import os
 from dotenv import load_dotenv
+
 # Load environment variables from .env file
 load_dotenv()
 
-class Singleton(type):
+class Config(object):
     """
-    Singleton metaclass for ensuring only one instance of a class.
+    A class to manage all configurations.
     """
-
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(
-                Singleton, cls).__call__(
-                *args, **kwargs)
-        return cls._instances[cls]
-
-
-class Config(metaclass=Singleton):
-    """
-    Configuration class to store the state of bools for different scripts access.
-    """
-
     def __init__(self):
-        self.debug = False
-        self.openai_api_key = os.getenv("OPENAI_API_KEY")
-        self.pexels_api_key = os.getenv("PEXELS_API_KEY")
-        self.shutterstock_api_key = os.getenv("SHUTTERSTOCK_API_KEY")
+        self.app_config = AppConfig()
+        self.script_config = ScriptConfig()
 
-    def get_or_throw(self, key):
-        value = getattr(self, key)
-        if value is None:
-            raise Exception(f"Missing config value: {key}")
-        return value
+    def app(self, property_name):
+        return self.app_config.get_property(property_name)
 
+    def script(self, property_name):
+        return self.script_config.get_property(property_name)
+
+    def __getattr__(self, property_name):
+        app_property = self.app(property_name)
+        if app_property is not None:
+            return app_property
+        script_property = self.script(property_name)
+        if script_property is not None:
+            return script_property
+
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{property_name}'")
+
+class AppConfig(object):
+    """
+    A class to manage app configurations.
+    """
+    def __init__(self):
+        self._config = {
+            "debug": False,
+            "openai_api_key": os.environ.get("OPENAI_API_KEY"),
+            "pexels_api_key": os.environ.get("PEXELS_API_KEY"),
+            "shutterstock_api_key": os.environ.get("SHUTTERSTOCK_API_KEY")
+        }
+
+    def get_property(self, property_name):
+        return self._config.get(property_name)
+    
     def set_debug(self, debug):
-        self.debug = debug
+        self._config["debug"] = debug
 
     def update_from_args(self, args):
         self.set_debug(args.debug)
 
     def log_args(self):
-        print(f"Debug mode: {self.debug}")
+        debug = self.get_property("debug")
+        print(f"Debug mode: {debug}")
+    
+class ScriptConfig(object):
+    """
+    A class to manage script configurations.
+    """
+    def __init__(self):
+        defaults = {
+            "script_style": "informative",
+            "max_content_length": 200,
+            "max_timeline_entries": 3,
+            "footage_engine": "pexels",
+            "footage_engine_settings": {}
+        }
+        with open("input/settings.yml", "r") as file:
+            input_settings = yaml.safe_load(file) or {}
+
+        input_settings = {**defaults, **input_settings}
+        self._config = input_settings
+
+    def get_property(self, property_name):
+        return self._config.get(property_name)


### PR DESCRIPTION
**WIP**
A refactor of config, based on feedback. 

Needs discussion.

Call signature:
```python
config = Config()

openai_api_key = config.app("openai_api_key")
print(openai_api_key)

max_timeline_entries = config.script("max_timeline_entries")
print(max_timeline_entries)

footage_engine = config.footage_engine
print(footage_engine)

print(config.app("debug"))
config.app_config.set_debug(True)
print(config.app("debug"))

config.app_config.log_args()
```

if you call with `config.app("invalid-value")` it will return None but if you call with `config.invalid-value` it will throw. We don't want this so need to discuss.